### PR TITLE
RollForm exposure & migration of mote .total to .max

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -1079,8 +1079,9 @@ export class ExaltedThirdActorSheet extends ActorSheet {
       }
     }
     if(item.type === 'spell') {
-      actorData.data.sorcery.motes = Math.max(0, actorData.data.sorcery.motes - item.data.data.cost);
+      actorData.data.sorcery.motes = 0;
     }
+    this._displayCard(event);
     this.actor.update(actorData);
   }
 }

--- a/module/apps/dice-roller.js
+++ b/module/apps/dice-roller.js
@@ -666,9 +666,11 @@ export class RollForm extends FormApplication {
         if (this._damageRollType('decisive')) {
             if (this.object.target && game.combat) {
                 let targetCombatant = game.combat.data.combatants.find(c => c?.actor?.data?._id == this.object.target.actor.id);
-                if (targetCombatant.actor.data.type === 'npc' || targetCombatant.actor.data.data.battlegroup) {
-                    dice += Math.floor(dice / 4);
-                    baseDamage = dice;
+                if(targetCombatant != null ) {
+                    if (targetCombatant.actor.data.type === 'npc' || targetCombatant.actor.data.data.battlegroup) {
+                        dice += Math.floor(dice / 4);
+                        baseDamage = dice;
+                    }
                 }
             }
         }

--- a/module/apps/dice-roller.js
+++ b/module/apps/dice-roller.js
@@ -672,7 +672,7 @@ export class RollForm extends FormApplication {
                             successModifier : this.object.successModifier,
                             total : this.object.total,
                             defense : this.object.defense,
-                            threshholdSucceses : this.object.thereshholdSuccesses
+                            threshholdSuccesses : this.object.thereshholdSuccesses
                         }
                     } 
                 });
@@ -715,7 +715,7 @@ export class RollForm extends FormApplication {
                         successModifier : this.object.successModifier,
                         total : this.object.total,
                         defense : this.object.defense,
-                        threshholdSucceses : this.object.thereshholdSuccesses
+                        threshholdSuccesses : this.object.thereshholdSuccesses
                     }
                 } 
             });
@@ -920,7 +920,7 @@ export class RollForm extends FormApplication {
                     successModifier : this.object.successModifier,
                     total : this.object.total,
                     defense : this.object.defense,
-                    threshholdSucceses : this.object.thereshholdSuccesses,
+                    threshholdSuccesses : this.object.thereshholdSuccesses,
                     damage : {
                         dice : baseDamage,
                         successModifier: this.object.damage.damageSuccessModifier,

--- a/module/apps/dice-roller.js
+++ b/module/apps/dice-roller.js
@@ -7,6 +7,7 @@ export class RollForm extends FormApplication {
             this.object = this.actor.data.data.savedRolls[data.rollId];
         }
         else {
+            this.object.crashed = false;
             this.object.dice = data.dice || 0;
             this.object.successModifier = 0;
             this.object.rollType = data.rollType;
@@ -203,6 +204,8 @@ export class RollForm extends FormApplication {
         }
     }
 
+    
+
     /**
    * Get the correct HTML template path to use for rendering this particular sheet
    * @type {String}
@@ -261,6 +264,30 @@ export class RollForm extends FormApplication {
         });
     }
 
+
+    resolve = function(value){ return value };
+
+    get resolve(){
+        return this.resolve
+    }
+
+    set resolve(value){
+        this.resolve = value;
+    }
+
+    /**
+     * Renders out the Roll form.
+     * @returns {Promise} Returns True or False once the Roll or Cancel buttons are pressed.
+     */
+    async roll() {
+        var _promiseResolve;
+        this.promise = new Promise(function (promiseResolve) {
+            _promiseResolve = promiseResolve
+        });
+        this.resolve = _promiseResolve; 
+        this.render(true); 
+        return this.promise;
+    }
     async _saveRoll(rollData) {
         let html = await renderTemplate("systems/exaltedthird/templates/dialogues/save-roll.html", {'name': this.object.name || 'New Roll'});
         new Dialog({
@@ -311,11 +338,13 @@ export class RollForm extends FormApplication {
         html.find('#roll-button').click((event) => {
             this._roll();
             if (this.object.intervals <= 0) {
+                this.resolve(true);
                 this.close();
             }
         });
 
         html.find('#cancel').click((event) => {
+            this.resolve(false);
             this.close();
         });
 
@@ -557,7 +586,20 @@ export class RollForm extends FormApplication {
       </div>
   </div>
   `
-        ChatMessage.create({ user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: this.actor }), content: theContent, type: CONST.CHAT_MESSAGE_TYPES.ROLL, roll: this.object.roll });
+        ChatMessage.create({ 
+            user: game.user.id, 
+            speaker: ChatMessage.getSpeaker({ actor: this.actor }), 
+            content: theContent, 
+            type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+             roll: this.object.roll,
+             flags: {
+                 "exaltedthird": {
+                     dice : this.object.dice,
+                     successModifier : this.object.successModifier,
+                     total : this.object.total
+                 }
+             } 
+            });
         if (this.object.rollType === "joinBattle") {
             let combat = game.combat;
             if (combat) {
@@ -619,7 +661,21 @@ export class RollForm extends FormApplication {
                     </div>
                 </div>
               `;
-                ChatMessage.create({ user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: this.actor }), content: messageContent, type: CONST.CHAT_MESSAGE_TYPES.ROLL, roll: this.object.roll });
+                ChatMessage.create({ 
+                    user: game.user.id, 
+                    speaker: ChatMessage.getSpeaker({ actor: this.actor }), 
+                    content: messageContent, 
+                    type: CONST.CHAT_MESSAGE_TYPES.ROLL, roll: this.object.roll,
+                    flags: {
+                        "exaltedthird": {
+                            dice : this.object.dice,
+                            successModifier : this.object.successModifier,
+                            total : this.object.total,
+                            defense : this.object.defense,
+                            threshholdSucceses : this.object.thereshholdSuccesses
+                        }
+                    } 
+                });
             }
         }
         if (this.object.rollType === 'accuracy') {
@@ -647,7 +703,22 @@ export class RollForm extends FormApplication {
                 </div>
             </div>
           `;
-            ChatMessage.create({ user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: this.actor }), content: messageContent, type: CONST.CHAT_MESSAGE_TYPES.ROLL, roll: this.object.roll });
+            ChatMessage.create({ 
+                user: game.user.id, 
+                speaker: ChatMessage.getSpeaker({ actor: this.actor }), 
+                content: messageContent, 
+                type: CONST.CHAT_MESSAGE_TYPES.ROLL, 
+                roll: this.object.roll,
+                flags: {
+                    "exaltedthird": {
+                        dice : this.object.dice,
+                        successModifier : this.object.successModifier,
+                        total : this.object.total,
+                        defense : this.object.defense,
+                        threshholdSucceses : this.object.thereshholdSuccesses
+                    }
+                } 
+            });
 
         }
     }
@@ -757,6 +828,7 @@ export class RollForm extends FormApplication {
                                 newInitative = 1;
                             }
                             else {
+                                this.object.crashed = true;
                                 this.object.characterInitiative += 5;
                                 targetResults = `<h4 class="dice-total">Target Crashed!</h4>`;
                             }
@@ -836,7 +908,29 @@ export class RollForm extends FormApplication {
           `;
         }
 
-        ChatMessage.create({ user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: this.actor }), content: messageContent, type: CONST.CHAT_MESSAGE_TYPES.ROLL, roll: this.object.roll || roll });
+        ChatMessage.create({ 
+            user: game.user.id, 
+            speaker: ChatMessage.getSpeaker({ actor: this.actor }), 
+            content: messageContent, 
+            type: CONST.CHAT_MESSAGE_TYPES.ROLL, 
+            roll: this.object.roll || roll,
+            flags: {
+                "exaltedthird": {
+                    dice : this.object.dice,
+                    successModifier : this.object.successModifier,
+                    total : this.object.total,
+                    defense : this.object.defense,
+                    threshholdSucceses : this.object.thereshholdSuccesses,
+                    damage : {
+                        dice : baseDamage,
+                        successModifier: this.object.damage.damageSuccessModifier,
+                        soak : this.object.soak,
+                        totalDamage : total,
+                        crashed: this.object.crashed
+                    }
+                }
+            }
+        });
 
         if (this.actor.data.type !== 'npc' || this.actor.data.data.battlegroup === false) {
             let combat = game.combat;
@@ -1000,7 +1094,20 @@ export class RollForm extends FormApplication {
     </div>
 </div>
 `
-        ChatMessage.create({ user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: this.actor }), content: messageContent, type: CONST.CHAT_MESSAGE_TYPES.ROLL, roll: this.object.roll });
+        ChatMessage.create({ 
+            user: game.user.id, 
+            speaker: ChatMessage.getSpeaker({ actor: this.actor }), 
+            content: messageContent, 
+            type: CONST.CHAT_MESSAGE_TYPES.ROLL, 
+            roll: this.object.roll,
+            flags: {
+                "exaltedthird": {
+                    dice : this.object.dice,
+                    successModifier : this.object.successModifier,
+                    total : this.object.total
+                }
+            } 
+        });
         this.object.goalNumber = goalNumberLeft;
         this.object.intervals--;
         if (this.object.intervals > 0) {

--- a/module/exaltedthird.js
+++ b/module/exaltedthird.js
@@ -16,14 +16,16 @@ Hooks.once('init', async function() {
 
   game.exaltedthird = {
     applications: {
-      TraitSelector,
+      TraitSelector
     },
     entities: {
       ExaltedThirdActor,
-      ExaltedThirdItem,
+      ExaltedThirdItem
     },
     config: exaltedthird,
-    rollItemMacro: rollItemMacro
+    rollItemMacro: rollItemMacro,
+    roll: roll,
+    RollForm
   };
 
   /**
@@ -230,4 +232,15 @@ function rollItemMacro(itemName) {
 
   // Trigger the item roll
   return item.roll();
+}
+
+/**
+ * 
+ * @param {ExaltedThirdActor} actor 
+ * @param {object} object 
+ * @param {object} data 
+ * @returns {Promise}
+ */
+function roll(actor,object,data){
+  return new RollForm(actor,object,{},data).render(true);
 }

--- a/module/exaltedthird.js
+++ b/module/exaltedthird.js
@@ -138,8 +138,8 @@ Hooks.on('updateCombat', (async (combat, update, diff, userId) => {
   if (update && update.round) {
     for(var combatant of combat.data.combatants) {
       const actorData = duplicate(combatant.actor)
-      var missingPersonal = actorData.data.motes.personal.total - actorData.data.motes.personal.value;
-      var missingPeripheral = actorData.data.motes.peripheral.total - actorData.data.motes.peripheral.value;
+      var missingPersonal = actorData.data.motes.personal.max - actorData.data.motes.personal.value;
+      var missingPeripheral = actorData.data.motes.peripheral.max - actorData.data.motes.peripheral.value;
       var restorePersonal = 0;
       var restorePeripheral = 0;
       if(missingPeripheral >= 5) {

--- a/module/exaltedthird.js
+++ b/module/exaltedthird.js
@@ -242,5 +242,5 @@ function rollItemMacro(itemName) {
  * @returns {Promise}
  */
 function roll(actor,object,data){
-  return new RollForm(actor,object,{},data).render(true);
+  return new RollForm(actor,object,{},data).roll();
 }

--- a/template.json
+++ b/template.json
@@ -46,11 +46,13 @@
         "motes": {
           "personal": {
             "value": 0,
-            "total": 0
+            "total": 0,
+            "max": 0
           },
           "peripheral": {
             "value": 0,
-            "total": 0
+            "total": 0,
+            "max":0
           }
         },
         "evasion": {

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -41,7 +41,7 @@
               <input type="number" name="data.motes.personal.value" value="{{data.data.motes.personal.value}}"
                 data-dtype="Number" />
               /
-              <input type="number" name="data.motes.personal.total" value="{{data.data.motes.personal.total}}"
+              <input type="number" name="data.motes.personal.max" value="{{data.data.motes.personal.max}}"
                 data-dtype="Number" />
             </div>
           </div>
@@ -51,7 +51,7 @@
               <input type="number" name="data.motes.peripheral.value" value="{{data.data.motes.peripheral.value}}"
                 data-dtype="Number" />
               /
-              <input type="number" name="data.motes.peripheral.total" value="{{data.data.motes.peripheral.total}}"
+              <input type="number" name="data.motes.peripheral.max" value="{{data.data.motes.peripheral.max}}"
                 data-dtype="Number" />
             </div>
           </div>

--- a/templates/actor/npc-sheet.html
+++ b/templates/actor/npc-sheet.html
@@ -83,8 +83,8 @@
                             <input type="number" name="data.motes.personal.value"
                                 value="{{data.data.motes.personal.value}}" data-dtype="Number" />
                             /
-                            <input type="number" name="data.motes.personal.total"
-                                value="{{data.data.motes.personal.total}}" data-dtype="Number" />
+                            <input type="number" name="data.motes.personal.max"
+                                value="{{data.data.motes.personal.max}}" data-dtype="Number" />
                         </div>
                     </div>
                     <div>
@@ -93,8 +93,8 @@
                             <input type="number" name="data.motes.peripheral.value"
                                 value="{{data.data.motes.peripheral.value}}" data-dtype="Number" />
                             /
-                            <input type="number" name="data.motes.peripheral.total"
-                                value="{{data.data.motes.peripheral.total}}" data-dtype="Number" />
+                            <input type="number" name="data.motes.peripheral.max"
+                                value="{{data.data.motes.peripheral.max}}" data-dtype="Number" />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This MR is made in response to #6 and #7. It is a simple change that does the following:

- The exposure of the `RollForm` class by adding it under `game.exaltedthird.RollForm`. Allowing users to make macros utilizing this object in the same manner in which the sheet does normally.
- Creation of the `.roll` method under `game.exaltedthird.roll()` which allows an alternate way of making simple rolls using the existing internal API.
- Change the actor's property names for the `motes.peripheral.total` and `motes.personal.total` to `motes.peripheral.max` and `motes.personal.max` (alongside changing all references to the code that point to these variables) so that foundry will recognize these 2 variables as resources and thus allow users to set them as their token's bars.

**Addition**
dice-roller.js was missing a null check which caused the dice roller to fail to do anything if the person rolling is in combat but the token they are targeting is not in the current combat. It's just a simple null check, nothing else was touched.