### PR TITLE
Improved Saved Rolls functionality

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -503,6 +503,11 @@ export class ExaltedThirdActorSheet extends ActorSheet {
       li.toggle("fast");
     });
 
+    html.find('.quick-roll').click(ev => {
+      let li = $(event.currentTarget).parents(".item");
+      new RollForm(this.actor, { event: ev }, {}, { rollId: li.data("item-id"), skipDialog: true }).roll();
+    });
+
     html.find('.saved-roll').click(ev => {
       let li = $(event.currentTarget).parents(".item");
       new RollForm(this.actor, { event: ev }, {}, { rollId: li.data("item-id") }).render(true);

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -12,9 +12,10 @@ export class ExaltedThirdActor extends Actor {
   prepareData() {
     super.prepareData();
 
+    const actorData = this;
     // Make separate methods for each Actor type (character, npc, etc.) to keep
     // things organized.
-    this._prepareCharacterData();
+    this._prepareCharacterData(actorData);
   }
 
   async displayEmbeddedItem(itemId) {
@@ -56,21 +57,21 @@ export class ExaltedThirdActor extends Actor {
 
     if(item.type === 'charm') {
       if(item.data.data.cost.motes > 0) {
-        if(actorData.data.motes.peripheral.value > 0 && !personal) {
-          actorData.data.motes.peripheral.value = Math.max(0, actorData.data.motes.peripheral.value - item.data.data.cost.motes);
+        if(data.data.motes.peripheral.value > 0 && !personal) {
+          data.data.motes.peripheral.value = Math.max(0, data.data.motes.peripheral.value - item.data.data.cost.motes);
         }
         else {
-          actorData.data.motes.personal.value = Math.max(0, actorData.data.motes.personal.value - item.data.data.cost.motes);
+          data.data.motes.personal.value = Math.max(0, data.data.motes.personal.value - item.data.data.cost.motes);
         }
       }
-      actorData.data.willpower.value = Math.max(0, actorData.data.willpower.value - item.data.data.cost.willpower);
+      data.data.willpower.value = Math.max(0, data.data.willpower.value - item.data.data.cost.willpower);
       if(this.type === 'character') {
-        actorData.data.craft.experience.silver.value = Math.max(0, actorData.data.craft.experience.silver.value - item.data.data.cost.silverxp);
-        actorData.data.craft.experience.gold.value = Math.max(0, actorData.data.craft.experience.gold.value - item.data.data.cost.goldxp);
-        actorData.data.craft.experience.white.value = Math.max(0, actorData.data.craft.experience.white.value - item.data.data.cost.whitexp);
+        data.data.craft.experience.silver.value = Math.max(0, data.data.craft.experience.silver.value - item.data.data.cost.silverxp);
+        data.data.craft.experience.gold.value = Math.max(0, data.data.craft.experience.gold.value - item.data.data.cost.goldxp);
+        data.data.craft.experience.white.value = Math.max(0, data.data.craft.experience.white.value - item.data.data.cost.whitexp);
       }
-      if(actorData.data.details.aura === item.data.data.cost.aura || item.data.data.cost.aura === 'any') {
-        actorData.data.details.aura = "none";
+      if(data.data.details.aura === item.data.data.cost.aura || item.data.data.cost.aura === 'any') {
+        data.data.details.aura = "none";
       }
       if(item.data.data.cost.initiative > 0) {
         let combat = game.combat;
@@ -86,7 +87,7 @@ export class ExaltedThirdActor extends Actor {
         }
       }
       if(item.data.data.cost.anima > 0) {
-        var newLevel = actorData.data.anima.level;
+        var newLevel = data.data.anima.level;
         for(var i = 0; i < item.data.data.cost.anima; i++) {
           if (newLevel === "Transcendent") {
             newLevel = "Bonfire";
@@ -101,26 +102,26 @@ export class ExaltedThirdActor extends Actor {
             newLevel = "Dim";
           }
         }
-        actorData.data.anima.level = newLevel;
+        data.data.anima.level = newLevel;
       }
       if(item.data.data.cost.health > 0) {
         let totalHealth = 0;
-        for (let [key, health_level] of Object.entries(actorData.data.health.levels)) {
+        for (let [key, health_level] of Object.entries(data.data.health.levels)) {
           totalHealth += health_level.value;
         }
         if(item.data.data.cost.healthtype === 'bashing') {
-          actorData.data.health.bashing = Math.min(totalHealth - actorData.data.health.aggravated - actorData.data.health.lethal, actorData.data.health.bashing + item.data.data.cost.health);
+          data.data.health.bashing = Math.min(totalHealth - data.data.health.aggravated - data.data.health.lethal, data.data.health.bashing + item.data.data.cost.health);
         }
         else if(item.data.data.cost.healthtype === 'lethal') {
-          actorData.data.health.lethal = Math.min(totalHealth - actorData.data.health.bashing - actorData.data.health.aggravated, actorData.data.health.lethal + item.data.data.cost.health);
+          data.data.health.lethal = Math.min(totalHealth - data.data.health.bashing - data.data.health.aggravated, data.data.health.lethal + item.data.data.cost.health);
         }
         else {
-          actorData.data.health.aggravated = Math.min(totalHealth - actorData.data.health.bashing - actorData.data.health.lethal, actorData.data.health.aggravated + item.data.data.cost.health);
+          data.data.health.aggravated = Math.min(totalHealth - data.data.health.bashing - data.data.health.lethal, data.data.health.aggravated + item.data.data.cost.health);
         }
       }
     }
     if(item.type === 'spell') {
-      actorData.data.sorcery.motes = 0;
+      data.data.sorcery.motes = 0;
     }
 
     this.displayEmbeddedItem(itemId);
@@ -152,10 +153,11 @@ export class ExaltedThirdActor extends Actor {
   /**
    * Prepare Character type specific data
    */
-  _prepareCharacterData() {
+  _prepareCharacterData(actorData) {
     // Make modifications to data here. For example:
 
-    const actorData = this;
+    const data = actorData.data.data;
+
     // this._prepareBaseActorData(data);
     let totalHealth = 0;
     let currentPenalty = 0;
@@ -164,73 +166,73 @@ export class ExaltedThirdActor extends Actor {
     let currentWarstriderPenalty = 0;
     let currentShipPenalty = 0;
 
-    if (actorData.data.data.battlegroup) {
-      totalHealth = actorData.data.data.health.levels.zero.value + actorData.data.data.size.value;
-      actorData.data.data.health.total = totalHealth;
-      if ((actorData.data.data.health.bashing + actorData.data.data.health.lethal + actorData.data.data.health.aggravated) > actorData.data.data.health.total) {
-        actorData.data.data.health.aggravated = actorData.data.data.health.total - actorData.data.data.health.lethal;
-        if (actorData.data.data.health.aggravated <= 0) {
-          actorData.data.data.health.aggravated = 0
-          actorData.data.data.health.lethal = actorData.data.data.health.total
+    if (data.battlegroup) {
+      totalHealth = data.health.levels.zero.value + data.size.value;
+      data.health.total = totalHealth;
+      if ((data.health.bashing + data.health.lethal + data.health.aggravated) > data.health.total) {
+        data.health.aggravated = data.health.total - data.health.lethal;
+        if (data.health.aggravated <= 0) {
+          data.health.aggravated = 0
+          data.health.lethal = data.health.total
         }
       }
-      actorData.data.data.health.penalty = 0;
+      data.health.penalty = 0;
     }
     else {
-      for (let [key, health_level] of Object.entries(actorData.data.data.health.levels)) {
-        if ((actorData.data.data.health.bashing + actorData.data.data.health.lethal + actorData.data.data.health.aggravated) > totalHealth) {
+      for (let [key, health_level] of Object.entries(data.health.levels)) {
+        if ((data.health.bashing + data.health.lethal + data.health.aggravated) > totalHealth) {
           currentPenalty = health_level.penalty;
         }
         totalHealth += health_level.value;
       }
-      actorData.data.data.health.total = totalHealth;
-      if ((actorData.data.data.health.bashing + actorData.data.data.health.lethal + actorData.data.data.health.aggravated) > actorData.data.data.health.total) {
-        actorData.data.data.health.aggravated = actorData.data.data.health.total - actorData.data.data.health.lethal;
-        if (actorData.data.data.health.aggravated <= 0) {
-          actorData.data.data.health.aggravated = 0;
-          actorData.data.data.health.lethal = actorData.data.data.health.total;
+      data.health.total = totalHealth;
+      if ((data.health.bashing + data.health.lethal + data.health.aggravated) > data.health.total) {
+        data.health.aggravated = data.health.total - data.health.lethal;
+        if (data.health.aggravated <= 0) {
+          data.health.aggravated = 0;
+          data.health.lethal = data.health.total;
         }
       }
-      actorData.data.data.health.penalty = currentPenalty;
+      data.health.penalty = currentPenalty;
     }
 
 
-    for (let [key, health_level] of Object.entries(actorData.data.data.warstrider.health.levels)) {
-      if ((actorData.data.data.warstrider.health.bashing + actorData.data.data.warstrider.health.lethal + actorData.data.data.warstrider.health.aggravated) > totalWarstriderHealth) {
+    for (let [key, health_level] of Object.entries(data.warstrider.health.levels)) {
+      if ((data.warstrider.health.bashing + data.warstrider.health.lethal + data.warstrider.health.aggravated) > totalWarstriderHealth) {
         currentWarstriderPenalty = health_level.penalty;
       }
       totalWarstriderHealth += health_level.value;
     }
-    actorData.data.data.warstrider.health.total = totalWarstriderHealth;
-    if ((actorData.data.data.warstrider.health.bashing + actorData.data.data.warstrider.health.lethal + actorData.data.data.warstrider.health.aggravated) > actorData.data.data.warstrider.health.total) {
-      actorData.data.warstrider.health.aggravated = actorData.data.warstrider.health.total - actorData.data.warstrider.health.lethal;
-      if (actorData.data.data.warstrider.health.aggravated <= 0) {
-        actorData.data.data.warstrider.health.aggravated = 0;
-        actorData.data.data.warstrider.health.lethal = actorData.data.data.health.total;
+    data.warstrider.health.total = totalWarstriderHealth;
+    if ((data.warstrider.health.bashing + data.warstrider.health.lethal + data.warstrider.health.aggravated) > data.warstrider.health.total) {
+      data.warstrider.health.aggravated = data.warstrider.health.total - data.warstrider.health.lethal;
+      if (data.warstrider.health.aggravated <= 0) {
+        data.warstrider.health.aggravated = 0;
+        data.warstrider.health.lethal = data.health.total;
       }
     }
-    actorData.data.data.warstrider.health.penalty = currentWarstriderPenalty;
+    data.warstrider.health.penalty = currentWarstriderPenalty;
 
     
-    for (let [key, health_level] of Object.entries(actorData.data.data.ship.health.levels)) {
-      if ((actorData.data.data.ship.health.bashing + actorData.data.data.ship.health.lethal + actorData.data.data.ship.health.aggravated) > totalShipHealth) {
+    for (let [key, health_level] of Object.entries(data.ship.health.levels)) {
+      if ((data.ship.health.bashing + data.ship.health.lethal + data.ship.health.aggravated) > totalShipHealth) {
         currentShipPenalty = health_level.penalty;
       }
       totalShipHealth += health_level.value;
     }
-    actorData.data.data.ship.health.total = totalShipHealth;
-    if ((actorData.data.data.ship.health.bashing + actorData.data.data.ship.health.lethal + actorData.data.data.ship.health.aggravated) > actorData.data.data.ship.health.total) {
-      actorData.data.data.ship.health.aggravated = actorData.data.data.ship.health.total - actorData.data.data.ship.health.lethal;
-      if (actorData.data.data.ship.health.aggravated <= 0) {
-        actorData.data.data.ship.health.aggravated = 0;
-        actorData.data.data.ship.health.lethal = actorData.data.data.health.total;
+    data.ship.health.total = totalShipHealth;
+    if ((data.ship.health.bashing + data.ship.health.lethal + data.ship.health.aggravated) > data.ship.health.total) {
+      data.ship.health.aggravated = data.ship.health.total - data.ship.health.lethal;
+      if (data.ship.health.aggravated <= 0) {
+        data.ship.health.aggravated = 0;
+        data.ship.health.lethal = data.health.total;
       }
     }
-    actorData.data.data.ship.health.penalty = currentShipPenalty;
+    data.ship.health.penalty = currentShipPenalty;
 
     if (actorData.type !== "npc") {
-      actorData.data.data.experience.standard.spent = actorData.data.data.experience.standard.total - actorData.data.data.experience.standard.value;
-      actorData.data.data.experience.exalt.spent = actorData.data.data.experience.exalt.total - actorData.data.data.experience.exalt.value;
+      data.experience.standard.spent = data.experience.standard.total - data.experience.standard.value;
+      data.experience.exalt.spent = data.experience.exalt.total - data.experience.exalt.value;
     }
 
     // Initialize containers.
@@ -365,7 +367,5 @@ export class ExaltedThirdActor extends Actor {
     actorData.specialabilities = specialAbilities;
     actorData.projects = craftProjects;
     actorData.actions = actions;
-
-    console.log(actorData);
   }
 }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -128,7 +128,7 @@ export class ExaltedThirdActor extends Actor {
     this.update(actorData);
   }
 
-  async rollSaved(name){
+  async savedRoll(name){
 
     const roll = Object.values(this.data.data.savedRolls).find(x=>x. name === name);
 

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1,3 +1,5 @@
+import { RollForm } from "../apps/dice-roller.js";
+
 /**
  * Extend the base Actor entity by defining a custom roll data structure which is ideal for the Simple system.
  * @extends {Actor}
@@ -10,10 +12,9 @@ export class ExaltedThirdActor extends Actor {
   prepareData() {
     super.prepareData();
 
-    const actorData = this.data;
     // Make separate methods for each Actor type (character, npc, etc.) to keep
     // things organized.
-    this._prepareCharacterData(actorData);
+    this._prepareCharacterData();
   }
 
   async displayEmbeddedItem(itemId) {
@@ -127,12 +128,34 @@ export class ExaltedThirdActor extends Actor {
     this.update(actorData);
   }
 
+  async rollSaved(name){
+
+    const roll = Object.values(this.data.data.savedRolls).find(x=>x. name === name);
+
+    if(!roll){
+      return ui.notifications.error(`${this.name} does not have a saved roll named ${name}!`);
+    }
+
+
+    await new RollForm(this, { event: this.event }, {}, { rollId: roll.id, skipDialog: true }).roll();
+  }
+
+  getSavedRoll(name){
+    const roll = Object.values(this.data.data.savedRolls).find(x=>x. name === name);
+
+    if(!roll){
+      return ui.notifications.error(`${this.name} does not have a saved roll named ${name}!`);
+    }
+
+    return new RollForm(this, { event: this.event }, {}, { rollId: roll.id });
+  }
   /**
    * Prepare Character type specific data
    */
-  _prepareCharacterData(actorData) {
+  _prepareCharacterData() {
     // Make modifications to data here. For example:
-    const data = actorData.data;
+
+    const actorData = this;
     // this._prepareBaseActorData(data);
     let totalHealth = 0;
     let currentPenalty = 0;
@@ -141,73 +164,208 @@ export class ExaltedThirdActor extends Actor {
     let currentWarstriderPenalty = 0;
     let currentShipPenalty = 0;
 
-    if (data.battlegroup) {
-      totalHealth = data.health.levels.zero.value + data.size.value;
-      data.health.total = totalHealth;
-      if ((data.health.bashing + data.health.lethal + data.health.aggravated) > data.health.total) {
-        data.health.aggravated = data.health.total - data.health.lethal;
-        if (data.health.aggravated <= 0) {
-          data.health.aggravated = 0
-          data.health.lethal = data.health.total
+    if (actorData.data.data.battlegroup) {
+      totalHealth = actorData.data.data.health.levels.zero.value + actorData.data.data.size.value;
+      actorData.data.data.health.total = totalHealth;
+      if ((actorData.data.data.health.bashing + actorData.data.data.health.lethal + actorData.data.data.health.aggravated) > actorData.data.data.health.total) {
+        actorData.data.data.health.aggravated = actorData.data.data.health.total - actorData.data.data.health.lethal;
+        if (actorData.data.data.health.aggravated <= 0) {
+          actorData.data.data.health.aggravated = 0
+          actorData.data.data.health.lethal = actorData.data.data.health.total
         }
       }
-      data.health.penalty = 0;
+      actorData.data.data.health.penalty = 0;
     }
     else {
-      for (let [key, health_level] of Object.entries(data.health.levels)) {
-        if ((data.health.bashing + data.health.lethal + data.health.aggravated) > totalHealth) {
+      for (let [key, health_level] of Object.entries(actorData.data.data.health.levels)) {
+        if ((actorData.data.data.health.bashing + actorData.data.data.health.lethal + actorData.data.data.health.aggravated) > totalHealth) {
           currentPenalty = health_level.penalty;
         }
         totalHealth += health_level.value;
       }
-      data.health.total = totalHealth;
-      if ((data.health.bashing + data.health.lethal + data.health.aggravated) > data.health.total) {
-        data.health.aggravated = data.health.total - data.health.lethal;
-        if (data.health.aggravated <= 0) {
-          data.health.aggravated = 0;
-          data.health.lethal = data.health.total;
+      actorData.data.data.health.total = totalHealth;
+      if ((actorData.data.data.health.bashing + actorData.data.data.health.lethal + actorData.data.data.health.aggravated) > actorData.data.data.health.total) {
+        actorData.data.data.health.aggravated = actorData.data.data.health.total - actorData.data.data.health.lethal;
+        if (actorData.data.data.health.aggravated <= 0) {
+          actorData.data.data.health.aggravated = 0;
+          actorData.data.data.health.lethal = actorData.data.data.health.total;
         }
       }
-      data.health.penalty = currentPenalty;
+      actorData.data.data.health.penalty = currentPenalty;
     }
 
 
-    for (let [key, health_level] of Object.entries(data.warstrider.health.levels)) {
-      if ((data.warstrider.health.bashing + data.warstrider.health.lethal + data.warstrider.health.aggravated) > totalWarstriderHealth) {
+    for (let [key, health_level] of Object.entries(actorData.data.data.warstrider.health.levels)) {
+      if ((actorData.data.data.warstrider.health.bashing + actorData.data.data.warstrider.health.lethal + actorData.data.data.warstrider.health.aggravated) > totalWarstriderHealth) {
         currentWarstriderPenalty = health_level.penalty;
       }
       totalWarstriderHealth += health_level.value;
     }
-    data.warstrider.health.total = totalWarstriderHealth;
-    if ((data.warstrider.health.bashing + data.warstrider.health.lethal + data.warstrider.health.aggravated) > data.warstrider.health.total) {
-      data.warstrider.health.aggravated = data.warstrider.health.total - data.warstrider.health.lethal;
-      if (data.warstrider.health.aggravated <= 0) {
-        data.warstrider.health.aggravated = 0;
-        data.warstrider.health.lethal = data.health.total;
+    actorData.data.data.warstrider.health.total = totalWarstriderHealth;
+    if ((actorData.data.data.warstrider.health.bashing + actorData.data.data.warstrider.health.lethal + actorData.data.data.warstrider.health.aggravated) > actorData.data.data.warstrider.health.total) {
+      actorData.data.warstrider.health.aggravated = actorData.data.warstrider.health.total - actorData.data.warstrider.health.lethal;
+      if (actorData.data.data.warstrider.health.aggravated <= 0) {
+        actorData.data.data.warstrider.health.aggravated = 0;
+        actorData.data.data.warstrider.health.lethal = actorData.data.data.health.total;
       }
     }
-    data.warstrider.health.penalty = currentWarstriderPenalty;
+    actorData.data.data.warstrider.health.penalty = currentWarstriderPenalty;
 
     
-    for (let [key, health_level] of Object.entries(data.ship.health.levels)) {
-      if ((data.ship.health.bashing + data.ship.health.lethal + data.ship.health.aggravated) > totalShipHealth) {
+    for (let [key, health_level] of Object.entries(actorData.data.data.ship.health.levels)) {
+      if ((actorData.data.data.ship.health.bashing + actorData.data.data.ship.health.lethal + actorData.data.data.ship.health.aggravated) > totalShipHealth) {
         currentShipPenalty = health_level.penalty;
       }
       totalShipHealth += health_level.value;
     }
-    data.ship.health.total = totalShipHealth;
-    if ((data.ship.health.bashing + data.ship.health.lethal + data.ship.health.aggravated) > data.ship.health.total) {
-      data.ship.health.aggravated = data.ship.health.total - data.ship.health.lethal;
-      if (data.ship.health.aggravated <= 0) {
-        data.ship.health.aggravated = 0;
-        data.ship.health.lethal = data.health.total;
+    actorData.data.data.ship.health.total = totalShipHealth;
+    if ((actorData.data.data.ship.health.bashing + actorData.data.data.ship.health.lethal + actorData.data.data.ship.health.aggravated) > actorData.data.data.ship.health.total) {
+      actorData.data.data.ship.health.aggravated = actorData.data.data.ship.health.total - actorData.data.data.ship.health.lethal;
+      if (actorData.data.data.ship.health.aggravated <= 0) {
+        actorData.data.data.ship.health.aggravated = 0;
+        actorData.data.data.ship.health.lethal = actorData.data.data.health.total;
       }
     }
-    data.ship.health.penalty = currentShipPenalty;
+    actorData.data.data.ship.health.penalty = currentShipPenalty;
 
     if (actorData.type !== "npc") {
-      data.experience.standard.spent = data.experience.standard.total - data.experience.standard.value;
-      data.experience.exalt.spent = data.experience.exalt.total - data.experience.exalt.value;
+      actorData.data.data.experience.standard.spent = actorData.data.data.experience.standard.total - actorData.data.data.experience.standard.value;
+      actorData.data.data.experience.exalt.spent = actorData.data.data.experience.exalt.total - actorData.data.data.experience.exalt.value;
     }
+
+    // Initialize containers.
+    const gear = [];
+    const weapons = [];
+    const armor = [];
+    const merits = [];
+    const intimacies = [];
+    const initiations = [];
+    const martialarts = [];
+    const crafts = [];
+    const specialties = [];
+    const specialAbilities = [];
+    const craftProjects = [];
+    const actions = [];
+
+
+    const charms = {
+      strength: { name: 'Ex3.Strength', visible: false, list: [] },
+      dexterity: { name: 'Ex3.Dexterity', visible: false, list: [] },
+      stamina: { name: 'Ex3.Stamina', visible: false, list: [] },
+      charisma: { name: 'Ex3.Charisma', visible: false, list: [] },
+      manipulation: { name: 'Ex3.Manipulation', visible: false, list: [] },
+      appearance: { name: 'Ex3.Appearance', visible: false, list: [] },
+      perception: { name: 'Ex3.Perception', visible: false, list: [] },
+      intelligence: { name: 'Ex3.Intelligence', visible: false, list: [] },
+      wits: { name: 'Ex3.Wits', visible: false, list: [] },
+      archery: { name: 'Ex3.Archery', visible: false, list: [] },
+      athletics: { name: 'Ex3.Athletics', visible: false, list: [] },
+      awareness: { name: 'Ex3.Awareness', visible: false, list: [] },
+      brawl: { name: 'Ex3.Brawl', visible: false, list: [] },
+      bureaucracy: { name: 'Ex3.Bureaucracy', visible: false, list: [] },
+      craft: { name: 'Ex3.Craft', visible: false, list: [] },
+      dodge: { name: 'Ex3.Dodge', visible: false, list: [] },
+      integrity: { name: 'Ex3.Integrity', visible: false, list: [] },
+      investigation: { name: 'Ex3.Investigation', visible: false, list: [] },
+      larceny: { name: 'Ex3.Larceny', visible: false, list: [] },
+      linguistics: { name: 'Ex3.Linguistics', visible: false, list: [] },
+      lore: { name: 'Ex3.Lore', visible: false, list: [] },
+      martialarts: { name: 'Ex3.MartialArts', visible: false, list: [] },
+      medicine: { name: 'Ex3.Medicine', visible: false, list: [] },
+      melee: { name: 'Ex3.Melee', visible: false, list: [] },
+      occult: { name: 'Ex3.Occult', visible: false, list: [] },
+      performance: { name: 'Ex3.Performance', visible: false, list: [] },
+      presence: { name: 'Ex3.Presence', visible: false, list: [] },
+      resistance: { name: 'Ex3.Resistance', visible: false, list: [] },
+      ride: { name: 'Ex3.Ride', visible: false, list: [] },
+      sail: { name: 'Ex3.Sail', visible: false, list: [] },
+      socialize: { name: 'Ex3.Socialize', visible: false, list: [] },
+      stealth: { name: 'Ex3.Stealth', visible: false, list: [] },
+      survival: { name: 'Ex3.Survival', visible: false, list: [] },
+      thrown: { name: 'Ex3.Thrown', visible: false, list: [] },
+      war: { name: 'Ex3.War', visible: false, list: [] },
+      evocation: { name: 'Ex3.Evocation', visible: false, list: [] },
+      other: { name: 'Ex3.Other', visible: false, list: [] },
+      universal: { name: 'Ex3.Universal', visible: false, list: [] },
+    }
+
+    const spells = {
+      terrestrial: { name: 'Ex3.Terrestrial', visible: false, list: [] },
+      celestial: { name: 'Ex3.Celestial', visible: false, list: [] },
+      solar: { name: 'Ex3.Solar', visible: false, list: [] },
+    }
+
+    // Iterate through items, allocating to containers
+    for (let i of actorData.items) {
+      let item = i.data;
+
+      item.img = i.img || DEFAULT_TOKEN;
+      if (i.type === 'item') {
+        gear.push(i);
+      }
+      else if (i.type === 'weapon') {
+        weapons.push(i);
+      }
+      else if (i.type === 'armor') {
+        armor.push(i);
+      }
+      else if (i.type === 'merit') {
+        merits.push(i);
+      }
+      else if (i.type === 'intimacy') {
+        intimacies.push(i);
+      }
+      else if (i.type === 'martialart') {
+        martialarts.push(i);
+      }
+      else if (i.type === 'craft') {
+        crafts.push(i);
+      }
+      else if (i.type === 'initiation') {
+        initiations.push(i);
+      }
+      else if (i.type === 'specialty') {
+        specialties.push(i);
+      }
+      else if (i.type === 'specialability') {
+        specialAbilities.push(i);
+      }
+      else if (i.type === 'craftproject') {
+        craftProjects.push(i);
+      }
+      else if (i.type === 'charm') {
+        if (i.data.ability !== undefined) {
+          charms[i.data.ability].list.push(i);
+          charms[i.data.ability].visible = true;
+        }
+      }
+      else if (i.type === 'spell') {
+        if (i.data.circle !== undefined) {
+          spells[i.data.circle].list.push(i);
+          spells[i.data.circle].visible = true;
+        }
+      }
+      else if (i.type === 'action') {
+        actions.push(i);
+      }
+    }
+
+    // Assign and return
+    actorData.gear = gear;
+    actorData.weapons = weapons;
+    actorData.armor = armor;
+    actorData.merits = merits;
+    actorData.martialarts = martialarts;
+    actorData.crafts = crafts;
+    actorData.initiations = initiations;
+    actorData.intimacies = intimacies;
+    actorData.specialties = specialties;
+    actorData.charms = charms;
+    actorData.spells = spells;
+    actorData.specialabilities = specialAbilities;
+    actorData.projects = craftProjects;
+    actorData.actions = actions;
+
+    console.log(actorData);
   }
 }

--- a/module/apps/dice-roller.js
+++ b/module/apps/dice-roller.js
@@ -5,12 +5,15 @@ export class RollForm extends FormApplication {
 
         if (data.rollId) {
             this.object = duplicate(this.actor.data.data.savedRolls[data.rollId]);
+            this.object.skipDialog = data.skipDialog || true;
+            this.object.isSavedRoll = true;
         }
         else {
+            this.object.isSavedRoll = false;
             this.object.skipDialog = data.skipDialog || true;
             this.object.crashed = false;
             this.object.dice = data.dice || 0;
-            this.object.successModifier = 0;
+            this.object.successModifier = data.successModifier || 0;
             this.object.rollType = data.rollType;
             this.object.craftType = data.craftType || 0;
             this.object.craftRating = data.craftRating || 0;
@@ -387,6 +390,13 @@ export class RollForm extends FormApplication {
             this._roll();
             if (this.object.intervals <= 0) {
                 this.resolve(true);
+                this.close();
+            }
+        });
+
+        html.find('#save-button').click((event) => {
+            this._saveRoll(this.object);
+            if (this.object.intervals <= 0) {
                 this.close();
             }
         });

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -330,7 +330,8 @@
             {{item.rollType}}
           </div>
           <div class="item-controls">
-            <a class="item-control saved-roll" title="Roll"><i class="fas fa-dice"></i></a>
+            <a class="item-control quick-roll" title="Roll"><i class="fas fa-dice"></i></a>
+            <a class="item-control saved-roll" title="Edit"><i class="fas fa-edit"></i></a>
             <a class="item-control delete-saved-roll" title="Delete Item"><i class="fas fa-trash"></i></a>
           </div>
         </li>

--- a/templates/dialogues/ability-roll.html
+++ b/templates/dialogues/ability-roll.html
@@ -17,7 +17,11 @@
         </div>
         {{/ifEquals}}
         <div class="d-flex">
+            {{#if data.isSavedRoll}}
+            <button type="button" id="save-button">Save</button>
+            {{else}}
             <button type="button" id="roll-button">Roll</button>
+            {{/if}}
             <button type="button" id="cancel">Cancel</button>
         </div>
         {{/if}}

--- a/templates/dialogues/attack-roll.html
+++ b/templates/dialogues/attack-roll.html
@@ -10,7 +10,11 @@
         {{> systems/exaltedthird/templates/dialogues/damage-roll.html}}
         {{/ifNotEquals}}
         <div class="d-flex">
+            {{#if data.isSavedRoll}}
+            <button type="button" id="save-button">Save</button>
+            {{else}}
             <button type="button" id="roll-button">Roll</button>
+            {{/if}}
             <button type="button" id="cancel">Cancel</button>
         </div>
         {{/if}}

--- a/templates/dialogues/dice-roll.html
+++ b/templates/dialogues/dice-roll.html
@@ -2,7 +2,11 @@
     <div class="sheet-body exaltedthird">
         {{> systems/exaltedthird/templates/dialogues/ability-base.html}}
         <div class="d-flex">
+            {{#if data.isSavedRoll}}
+            <button type="button" id="save-button">Save</button>
+            {{else}}
             <button type="button" id="roll-button">Roll</button>
+            {{/if}}
             <button type="button" id="cancel">Cancel</button>
         </div>
     </div>


### PR DESCRIPTION
This merge request contains two important updates to Saved Rolls as well as an important fix to the data structure of the Actor document.

## Saved Roll Quick-Rolling & Roll Editing
The buttons on the saved rolls have been changed to now be 3 rolls: A roll button that bypasses the roll dialog entirely. Making it a truly quick and saved roll. And edit button which opens the roll dialog (The Roll button also being replaced with a "Save" button which mirrors the functionality of the "Update" button on the dialog's header) and the Delete button which has been unchanged.

![image](https://user-images.githubusercontent.com/4214215/175980531-f1e9c7be-c47d-433e-a023-70868aa9c6ce.png)
![image](https://user-images.githubusercontent.com/4214215/175980575-2ef055a1-24a4-4c0a-a3c9-9b77f55abbc1.png)


## Saved Roll API
Two new methods under the Actor class have been added to go hand in hand with this saved roll improvements. 

### savedRoll()
This method allows the user to quickly roll any saved roll on the actor by providing the exact name of the saved roll. This method is asynchronous, which means the user can await it if they need to. This roll also bypasses the roll dialog by default. Usage is as follows:

```js
if(actor){
    await actor.savedRoll("My saved roll");
}
```

### getSavedRoll()
This method is almost identical to the savedRoll method, but it just returns the finished RollForm for the user to make any last-minute modifications. Usage is as follows:

```js
if(actor){
   let form = actor.getSavedRoll('My saved roll');

   form.object.dice += 2;

   await form.roll();
}
```


## API hotfixes
Several fields in the Actor document (namely those listing specialties, charms, and other items from the actor) were *not* being populated until the character sheet was opened for the first time. This is bad because it means that a user who just logs into foundry and tries to use the new API methods to roll dice without having opened their sheet at least once will find itself with silent errors on the console about fields not being defined. 

To fix this, I simply mirrored the code on actor-sheet.js that initializes these fields onto actor.js's `_prepareCharacterData()` method. Making these fields initialized the moment the actor itself is loaded.