### PR TITLE
Solar peripheral motes calculation: Fix base value

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -230,7 +230,7 @@
     "Ex3.Third": "Third",
 
     "Ex3.Universal": "Universal",
-    "Ex3.Offsensive": "Offsensive",
+    "Ex3.Offensive": "Offensive",
     "Ex3.Defensive": "Defensive",
 
     "Ex3.Necromancy": "Necromancy",

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -699,7 +699,7 @@ export class ExaltedThirdActorSheet extends ActorSheet {
     }
     else {
       if (data.details.exalt === 'solar' || data.details.exalt === 'abyssal') {
-        data.motes.peripheral.max = 27 + (data.essence.value * 7);
+        data.motes.peripheral.max = 26 + (data.essence.value * 7);
       }
       if (data.details.exalt === 'dragonblooded') {
         data.motes.peripheral.max = 23 + (data.essence.value * 4);

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -131,7 +131,7 @@ export class ExaltedThirdActorSheet extends ActorSheet {
       evocation: { name: 'Ex3.Evocation', visible: false, list: [] },
       other: { name: 'Ex3.Other', visible: false, list: [] },
       universal: { name: 'Ex3.Universal', visible: false, list: [] },
-      offsensive: { name: 'Ex3.Offsensive', visible: false, list: [] },
+      offsensive: { name: 'Ex3.Offensive', visible: false, list: [] },
       defensive: { name: 'Ex3.Defensive', visible: false, list: [] },
       social: { name: 'Ex3.Social', visible: false, list: [] },
     }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -222,7 +222,7 @@ export class ExaltedThirdActor extends Actor {
     data.warstrider.health.value = data.warstrider.health.max - data.warstrider.health.aggravated - data.warstrider.health.lethal - data.warstrider.health.bashing;
     data.warstrider.health.penalty = currentWarstriderPenalty;
 
-    
+
     for (let [key, health_level] of Object.entries(data.ship.health.levels)) {
       if ((data.ship.health.bashing + data.ship.health.lethal + data.ship.health.aggravated) > totalShipHealth) {
         currentShipPenalty = health_level.penalty;
@@ -299,7 +299,7 @@ export class ExaltedThirdActor extends Actor {
       evocation: { name: 'Ex3.Evocation', visible: false, list: [] },
       other: { name: 'Ex3.Other', visible: false, list: [] },
       universal: { name: 'Ex3.Universal', visible: false, list: [] },
-      offsensive: { name: 'Ex3.Offsensive', visible: false, list: [] },
+      offsensive: { name: 'Ex3.Offensive', visible: false, list: [] },
       defensive: { name: 'Ex3.Defensive', visible: false, list: [] },
       social: { name: 'Ex3.Social', visible: false, list: [] },
     }

--- a/templates/item/item-charm-sheet.html
+++ b/templates/item/item-charm-sheet.html
@@ -44,7 +44,7 @@
                     <option value="war">{{localize "Ex3.War"}}</option>
                     <option value="evocation">{{localize "Ex3.Evocation"}}</option>
                     <option value="universal">{{localize "Ex3.Universal"}}</option>
-                    <option value="offsensive">{{localize "Ex3.Offsensive"}}</option>
+                    <option value="offsensive">{{localize "Ex3.Offensive"}}</option>
                     <option value="defensive">{{localize "Ex3.Defensive"}}</option>
                     <option value="social">{{localize "Ex3.Social"}}</option>
                     <option value="other">{{localize "Ex3.Other"}}</option>


### PR DESCRIPTION
Here is a small fix: The base value for calculating Solar peripheral motes is supposed to be 26, not 27.

In addition, I spotted and fixed a typo in QC charm categories ("Offsensive" should be "Offensive").