### PR TITLE
Add "War" to charm sheet (fix #20)

### DIFF
--- a/templates/item/item-charm-sheet.html
+++ b/templates/item/item-charm-sheet.html
@@ -41,6 +41,7 @@
                     <option value="stealth">{{localize "Ex3.Stealth"}}</option>
                     <option value="survival">{{localize "Ex3.Survival"}}</option>
                     <option value="thrown">{{localize "Ex3.Thrown"}}</option>
+                    <option value="war">{{localize "Ex3.War"}}</option>
                     <option value="journeys">{{localize "Ex3.Journeys"}}</option>
                     <option value="serenity">{{localize "Ex3.Serenity"}}</option>
                     <option value="battles">{{localize "Ex3.Battles"}}</option>


### PR DESCRIPTION
After reviewing the code, it appears the War ability was only omitted from the template for Charms - it appears everywhere else. This PR adds it between Thrown and Journeys and uses the existing localization string.

Fixes #20 