### PR TITLE
feat: Added settings, lang and function to enable/disable sorting of dice

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -664,6 +664,8 @@
     "Ex3.UseEssenceGambitsDescription": "Adds gambits from Essence that are missing from Exalted Third Edition.  Changes: Each gambit costs 1 less than Essence, pilfer does not give any power because that mechanic is not in Ex3, and Reveal Weakness will always half the targets soak until the next successful withering attack against them.  Defense penalties are calculated based off the gambits initiative roll.",
     "Ex3.DisengageCost": "Disengage Cost",
     "Ex3.DisengageCostDescription": "Disengage Costs 2 Initiative",
+    "Ex3.sortDice": "Sort Dice Rolls",
+    "Ex3.sortDiceDescription": "If selected, the dice roller will sort the results from 10 to 1. Otherwise, the dice will be shown in the order they were rolled.",
 
     "Ex3.RollButtonTarget": "Roll Button Target",
     "Ex3.RollButtonTargetDescription": "If enabled roll buttons will on the tokens that are currently targetted by the user and if there are no targets will default to the proper character (Attacker for gain withering, Target for Damage).  If disabled it will always use the Attacker/Defender.",

--- a/module/apps/dice-roller.js
+++ b/module/apps/dice-roller.js
@@ -2485,7 +2485,7 @@ export class RollForm extends FormApplication {
 
         possibleRerolls = 0;
         possibleSuccessRerolls = 0;
-        for (const diceResult of diceRoll.sort((a, b) => a.result - b.result)) {
+        for (const diceResult of this._sortDice(diceRoll)) {
             if (diceModifiers.rerollNumber > possibleRerolls && !diceResult.rerolled && diceResult.result < this.object.targetNumber && (!diceModifiers.settings.excludeOnesFromRerolls || diceResult.result !== 1)) {
                 possibleRerolls++;
                 diceResult.rerolled = true;
@@ -2507,7 +2507,7 @@ export class RollForm extends FormApplication {
             rerolledDice += possibleRerolls;
             var rerollNumDiceResults = await this._rollTheDice(diceToReroll, diceModifiers, doublesRolled, numbersRerolled);
             diceToReroll = 0
-            for (const diceResult of rerollNumDiceResults.results.sort((a, b) => a.result - b.result)) {
+            for (const diceResult of this._sortDice(rerollNumDiceResults.results)) {
                 if (diceModifiers.rerollNumber > possibleRerolls && !diceResult.rerolled && diceResult.result < this.object.targetNumber && (!diceModifiers.settings.excludeOnesFromRerolls || diceResult.result !== 1)) {
                     possibleRerolls++;
                     diceToReroll++;
@@ -2523,7 +2523,7 @@ export class RollForm extends FormApplication {
             successRerolledDice += possibleSuccessRerolls;
             var rerollNumDiceResults = await this._rollTheDice(successesToReroll, diceModifiers, doublesRolled, numbersRerolled);
             successesToReroll = 0
-            for (const diceResult of rerollNumDiceResults.results.sort((a, b) => a.result - b.result)) {
+            for (const diceResult of this._sortDice(rerollNumDiceResults.results)) {
                 if (diceModifiers.rerollSuccesses > possibleSuccessRerolls && !diceResult.rerolled && diceResult.result >= this.object.targetNumber) {
                     possibleSuccessRerolls++;
                     successesToReroll++;
@@ -2567,7 +2567,7 @@ export class RollForm extends FormApplication {
         rollResults.roll.dice[0].results = diceRoll;
 
         let diceDisplay = "";
-        for (let dice of diceRoll.sort((a, b) => b.result - a.result)) {
+        for (let dice of this._sortDice(diceRoll)) {
             if (dice.successCanceled) { diceDisplay += `<li class="roll die d10 rerolled">${dice.result}</li>`; }
             else if (dice.doubled) {
                 diceDisplay += `<li class="roll die d10 success double-success">${dice.result}</li>`;
@@ -5615,6 +5615,20 @@ export class RollForm extends FormApplication {
                 console.error(e);
             }
         }
+    }
+
+    _sortDice(diceRoll, ignoreSetting = false){
+        //ignoreSetting = true will always sort dice
+
+        var sortedDice;
+
+        if(game.settings.get('exaltedthird','sortDice') || ignoreSetting === true){  
+            sortedDice = diceRoll.sort((a, b) => b.result - a.result);
+        }else{
+            sortedDice = diceRoll;
+        }
+        
+        return sortedDice;
     }
 }
 

--- a/module/settings.js
+++ b/module/settings.js
@@ -149,6 +149,16 @@ export function registerSettings() {
         default: true
     });
 
+    game.settings.register("exaltedthird", "sortDice", {
+        name: game.i18n.localize('Ex3.sortDice'),
+        hint: game.i18n.localize('Ex3.sortDiceDescription'),
+        scope: "world",
+        config: true,
+        type: Boolean,
+        ruleChange: false,
+        default: true
+    });
+
     game.settings.register("exaltedthird", "unifiedCharacterCreation", {
         name: game.i18n.localize('Ex3.UnifiedCharacterCreation'),
         hint: game.i18n.localize('Ex3.UnifiedCharacterCreationDescription'),


### PR DESCRIPTION
Added a setting to enable or disable the sorting of dice for gm's that like to make decisions on close calls based on the first/last rolled dice and for people that just like chaos. 

I hope I did not ignore that the sorting is important for some evaluations - didn't see any connections there. 