### PR TITLE
On  the Character sheet, "Import"ing charms should search compendiums

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -634,6 +634,9 @@
     "Ex3.OpposedRolls": "Opposed Rolls",
     "Ex3.TurnTaken": "Turn Taken",
 
+    "Ex3.SearchCompendiums": "Search Compendiums",
+    "Ex3.SearchCompendiumsDescription": "When enabled, importing charms from a character sheet should search compendiums. WARNING: this option potentially has a steep performance cost. Use with caution.",
+
     "Ex3.Warstrider": "Warstrider",
     "Ex3.Ship": "Ship",
     "Ex3.ShipSpeed": "Ship Speed",

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -2458,8 +2458,35 @@ export class ExaltedThirdActorSheet extends HandlebarsApplicationMixin(ActorShee
       return;
     }
     let itemType = target.dataset.type;
+    let searchCompendiums = game.settings.get('exaltedthird', 'searchCompendiums');
 
-    let items = game.items.filter(item => item.type === itemType && this.actor.canAquireItem(item));
+    let filterFun = item => item.type === itemType && this.actor.canAquireItem(item);
+    // Loading from compendiums can take a little while, especially if you have
+    //  Compendiums for all charms from all exalt types
+    var packItems = [];
+
+    if (searchCompendiums) {
+      let packPromises = game.packs
+        .filter(p => p.metadata.type == "Item" && (game.user.isGM || !p.private))
+        .map(async p => {
+          // If we already loaded the compendium into memory, use them.
+          //  This decreases load time with thousands of items in
+          //  compendium from ~2 seconds down to effectively instantaneous.
+          //  We still have to wait the first time, but not afterwards.
+          //  Foundry *does* unload compendiums if they are unused for some time,
+          //  so we have to check every time.
+          let contents = p.contents;
+          if (contents.length == p.index.size) {
+            return contents;
+          } else {
+            return await p.getDocuments();
+          }
+        });
+      packItems = await Promise.all(packPromises);
+    }
+    // This ends the potentially slow part.
+
+    let items = game.items.filter(filterFun).concat(packItems.flatMap(p => p.filter(filterFun)));
 
     for (let item of items) {
       item.enritchedHTML = await foundry.applications.ux.TextEditor.implementation.enrichHTML(item.system.description, { async: true, secrets: true, relativeTo: item });

--- a/module/settings.js
+++ b/module/settings.js
@@ -197,6 +197,16 @@ export function registerSettings() {
         default: true
     });
 
+    game.settings.register("exaltedthird", "searchCompendiums", {
+        name: game.i18n.localize('Ex3.SearchCompendiums'),
+        hint: game.i18n.localize('Ex3.SearchCompendiumsDescription'),
+        scope: "world",
+        config: true,
+        type: Boolean,
+        ruleChange: false,
+        default: false
+    });
+
     game.settings.register("exaltedthird", "unifiedCharacterCreation", {
         name: game.i18n.localize('Ex3.UnifiedCharacterCreation'),
         hint: game.i18n.localize('Ex3.UnifiedCharacterCreationDescription'),


### PR DESCRIPTION
For my own games, I've created a series of compendiums with a _lot_ of charms.

Today, I import from the compendiums (taking care to keep the document IDs), and run a script to grant observer rights to all players.

This takes some time, and is error prone.

If this PR is merged, the character sheet charm importer will scan the compendiums when choosing which charms to display.

One reason *not* to merge this is the first-time load performance cost. With 3850 charms in compendiums, it takes about 3 seconds with my PC and my server, but it could be worse on smaller servers. I did include a performance optimization to reduce this time on subsequent uses.